### PR TITLE
fix: fixed the issue where some tlds that were a subset of other tlds were not included in the tld list.

### DIFF
--- a/TldExtract/TldExtract.cs
+++ b/TldExtract/TldExtract.cs
@@ -100,6 +100,9 @@ namespace NStack
 
 					t.matches [label] = m;
 				}
+				else if (i == 0) {
+					m.ValidTld = true;
+				}
 				t = m;
 			}
 		}


### PR DESCRIPTION
example: us-east-1.amazonaws.com was not matching properly because of other tlds like s3.us-east-1.amazonaws.com.